### PR TITLE
Add Live Photo support with motion video backup

### DIFF
--- a/swift/Sources/PhotosSyncLib/Database/Tracker.swift
+++ b/swift/Sources/PhotosSyncLib/Database/Tracker.swift
@@ -29,6 +29,7 @@ public final class Tracker: @unchecked Sendable {
     }
     
     private func createTables() throws {
+        // Only create basic table structure - indexes for new columns handled in migrations
         let sql = """
             CREATE TABLE IF NOT EXISTS imported_assets (
                 icloud_uuid TEXT PRIMARY KEY,
@@ -43,7 +44,6 @@ public final class Tracker: @unchecked Sendable {
             CREATE INDEX IF NOT EXISTS idx_imported_at ON imported_assets(imported_at);
             CREATE INDEX IF NOT EXISTS idx_media_type ON imported_assets(media_type);
             CREATE INDEX IF NOT EXISTS idx_immich_id ON imported_assets(immich_id);
-            CREATE INDEX IF NOT EXISTS idx_archived ON imported_assets(archived);
         """
         
         var errMsg: UnsafeMutablePointer<CChar>?
@@ -52,6 +52,76 @@ public final class Tracker: @unchecked Sendable {
             sqlite3_free(errMsg)
             throw TrackerError.execFailed(error)
         }
+        
+        // Run migrations to add columns/indexes for existing databases
+        try runMigrations()
+    }
+    
+    private func runMigrations() throws {
+        // SQLite doesn't support IF NOT EXISTS for ALTER TABLE, so we check column existence
+        let columns = getColumnNames(table: "imported_assets")
+        var errMsg: UnsafeMutablePointer<CChar>?
+        
+        // Migration 0: Add archived column (was in Swift schema but not Python-created DBs)
+        if !columns.contains("archived") {
+            let sql = "ALTER TABLE imported_assets ADD COLUMN archived INTEGER DEFAULT 0"
+            if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+                let error = errMsg.map { String(cString: $0) } ?? "Unknown error"
+                sqlite3_free(errMsg)
+                throw TrackerError.execFailed("Migration failed (archived): \(error)")
+            }
+            // Create index for archived column
+            let indexSql = "CREATE INDEX IF NOT EXISTS idx_archived ON imported_assets(archived)"
+            sqlite3_exec(db, indexSql, nil, nil, &errMsg)
+            sqlite3_free(errMsg)
+            errMsg = nil
+        }
+        
+        // Migration 1: Add Live Photo columns
+        // Use DEFAULT NULL so existing rows have unknown status (needing verification)
+        if !columns.contains("is_live_photo") {
+            let sql = "ALTER TABLE imported_assets ADD COLUMN is_live_photo INTEGER DEFAULT NULL"
+            if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+                let error = errMsg.map { String(cString: $0) } ?? "Unknown error"
+                sqlite3_free(errMsg)
+                throw TrackerError.execFailed("Migration failed (is_live_photo): \(error)")
+            }
+        }
+        
+        if !columns.contains("motion_video_immich_id") {
+            let sql = "ALTER TABLE imported_assets ADD COLUMN motion_video_immich_id TEXT"
+            if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+                let error = errMsg.map { String(cString: $0) } ?? "Unknown error"
+                sqlite3_free(errMsg)
+                throw TrackerError.execFailed("Migration failed (motion_video_immich_id): \(error)")
+            }
+        }
+        
+        // Create index for Live Photo queries
+        let indexSql = "CREATE INDEX IF NOT EXISTS idx_is_live_photo ON imported_assets(is_live_photo)"
+        if sqlite3_exec(db, indexSql, nil, nil, &errMsg) != SQLITE_OK {
+            // Index creation failure is non-fatal
+            sqlite3_free(errMsg)
+        }
+    }
+    
+    private func getColumnNames(table: String) -> Set<String> {
+        var columns = Set<String>()
+        let sql = "PRAGMA table_info(\(table))"
+        var stmt: OpaquePointer?
+        
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return columns
+        }
+        defer { sqlite3_finalize(stmt) }
+        
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let cString = sqlite3_column_text(stmt, 1) {  // Column 1 is 'name'
+                columns.insert(String(cString: cString))
+            }
+        }
+        
+        return columns
     }
     
     public func isImported(uuid: String) -> Bool {
@@ -95,13 +165,15 @@ public final class Tracker: @unchecked Sendable {
         immichID: String?,
         filename: String,
         fileSize: Int64,
-        mediaType: String
+        mediaType: String,
+        isLivePhoto: Bool = false,
+        motionVideoImmichID: String? = nil
     ) throws {
         try queue.sync {
             let sql = """
                 INSERT OR REPLACE INTO imported_assets 
-                (icloud_uuid, immich_id, filename, file_size, media_type, imported_at)
-                VALUES (?, ?, ?, ?, ?, datetime('now'))
+                (icloud_uuid, immich_id, filename, file_size, media_type, imported_at, is_live_photo, motion_video_immich_id)
+                VALUES (?, ?, ?, ?, ?, datetime('now'), ?, ?)
             """
             var stmt: OpaquePointer?
             
@@ -119,6 +191,12 @@ public final class Tracker: @unchecked Sendable {
             sqlite3_bind_text(stmt, 3, filename, -1, SQLITE_TRANSIENT)
             sqlite3_bind_int64(stmt, 4, fileSize)
             sqlite3_bind_text(stmt, 5, mediaType, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int(stmt, 6, isLivePhoto ? 1 : 0)
+            if let motionVideoImmichID = motionVideoImmichID {
+                sqlite3_bind_text(stmt, 7, motionVideoImmichID, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(stmt, 7)
+            }
             
             if sqlite3_step(stmt) != SQLITE_DONE {
                 throw TrackerError.execFailed(String(cString: sqlite3_errmsg(db)))
@@ -278,6 +356,176 @@ public final class Tracker: @unchecked Sendable {
                 throw TrackerError.execFailed(String(cString: sqlite3_errmsg(db)))
             }
         }
+    }
+    
+    // MARK: - Live Photo Support
+    
+    /// Get the motion video Immich ID for a Live Photo
+    public func getMotionVideoImmichID(uuid: String) -> String? {
+        queue.sync {
+            let sql = "SELECT motion_video_immich_id FROM imported_assets WHERE icloud_uuid = ?"
+            var stmt: OpaquePointer?
+            
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return nil
+            }
+            defer { sqlite3_finalize(stmt) }
+            
+            sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT)
+            
+            if sqlite3_step(stmt) == SQLITE_ROW, let cString = sqlite3_column_text(stmt, 0) {
+                return String(cString: cString)
+            }
+            return nil
+        }
+    }
+    
+    /// Check if an asset is a Live Photo
+    public func isLivePhoto(uuid: String) -> Bool {
+        queue.sync {
+            let sql = "SELECT is_live_photo FROM imported_assets WHERE icloud_uuid = ? LIMIT 1"
+            var stmt: OpaquePointer?
+            
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return false
+            }
+            defer { sqlite3_finalize(stmt) }
+            
+            sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT)
+            
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                return sqlite3_column_int(stmt, 0) == 1
+            }
+            return false
+        }
+    }
+    
+    /// Check if a Live Photo has its motion video backed up
+    public func hasMotionVideoBackup(uuid: String) -> Bool {
+        queue.sync {
+            let sql = "SELECT motion_video_immich_id FROM imported_assets WHERE icloud_uuid = ? AND is_live_photo = 1"
+            var stmt: OpaquePointer?
+            
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return false
+            }
+            defer { sqlite3_finalize(stmt) }
+            
+            sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT)
+            
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                // Check if motion_video_immich_id is not NULL
+                return sqlite3_column_type(stmt, 0) != SQLITE_NULL
+            }
+            return false
+        }
+    }
+    
+    /// Info about a Live Photo needing repair
+    public struct LivePhotoRepairInfo {
+        public let uuid: String
+        public let immichID: String?
+        public let filename: String
+    }
+    
+    /// Get Live Photos that were imported without their motion video (need repair)
+    /// These are assets where is_live_photo = 1 but motion_video_immich_id IS NULL
+    /// Also includes old imports where is_live_photo is NULL (unknown status)
+    public func getLivePhotosNeedingRepair() -> [LivePhotoRepairInfo] {
+        queue.sync {
+            var results: [LivePhotoRepairInfo] = []
+            
+            // Find assets that are known Live Photos without motion video backup
+            // OR assets with unknown Live Photo status (pre-migration imports)
+            let sql = """
+                SELECT icloud_uuid, immich_id, filename FROM imported_assets 
+                WHERE (is_live_photo = 1 AND motion_video_immich_id IS NULL)
+                   OR is_live_photo IS NULL
+                ORDER BY imported_at ASC
+            """
+            var stmt: OpaquePointer?
+            
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return results
+            }
+            defer { sqlite3_finalize(stmt) }
+            
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let uuidCStr = sqlite3_column_text(stmt, 0) else { continue }
+                let uuid = String(cString: uuidCStr)
+                
+                let immichID: String?
+                if let immichCStr = sqlite3_column_text(stmt, 1) {
+                    immichID = String(cString: immichCStr)
+                } else {
+                    immichID = nil
+                }
+                
+                let filename: String
+                if let filenameCStr = sqlite3_column_text(stmt, 2) {
+                    filename = String(cString: filenameCStr)
+                } else {
+                    filename = ""
+                }
+                
+                results.append(LivePhotoRepairInfo(uuid: uuid, immichID: immichID, filename: filename))
+            }
+            
+            return results
+        }
+    }
+    
+    /// Update an existing asset to mark it as a Live Photo with motion video
+    public func updateLivePhotoInfo(uuid: String, isLivePhoto: Bool, motionVideoImmichID: String?) throws {
+        try queue.sync {
+            let sql = "UPDATE imported_assets SET is_live_photo = ?, motion_video_immich_id = ? WHERE icloud_uuid = ?"
+            var stmt: OpaquePointer?
+            
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw TrackerError.prepareFailed(String(cString: sqlite3_errmsg(db)))
+            }
+            defer { sqlite3_finalize(stmt) }
+            
+            sqlite3_bind_int(stmt, 1, isLivePhoto ? 1 : 0)
+            if let motionVideoImmichID = motionVideoImmichID {
+                sqlite3_bind_text(stmt, 2, motionVideoImmichID, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(stmt, 2)
+            }
+            sqlite3_bind_text(stmt, 3, uuid, -1, SQLITE_TRANSIENT)
+            
+            if sqlite3_step(stmt) != SQLITE_DONE {
+                throw TrackerError.execFailed(String(cString: sqlite3_errmsg(db)))
+            }
+        }
+    }
+    
+    /// Get count of Live Photos and those with motion video backed up
+    public func getLivePhotoStats() -> (total: Int, withMotionVideo: Int, needingRepair: Int) {
+        var total = 0
+        var withMotionVideo = 0
+        var needingRepair = 0
+        
+        // Total Live Photos
+        if let count = querySingleInt("SELECT COUNT(*) FROM imported_assets WHERE is_live_photo = 1") {
+            total = count
+        }
+        
+        // With motion video backup
+        if let count = querySingleInt("SELECT COUNT(*) FROM imported_assets WHERE is_live_photo = 1 AND motion_video_immich_id IS NOT NULL") {
+            withMotionVideo = count
+        }
+        
+        // Needing repair (known Live Photos without motion video + unknown status)
+        if let count = querySingleInt("""
+            SELECT COUNT(*) FROM imported_assets 
+            WHERE (is_live_photo = 1 AND motion_video_immich_id IS NULL)
+               OR is_live_photo IS NULL
+        """) {
+            needingRepair = count
+        }
+        
+        return (total, withMotionVideo, needingRepair)
     }
 }
 

--- a/swift/Tests/PhotosSyncTests/Immich/ImmichClient.spec.swift
+++ b/swift/Tests/PhotosSyncTests/Immich/ImmichClient.spec.swift
@@ -436,4 +436,104 @@ struct ImmichClientSpec {
         
         _ = await client.ping()
     }
+    
+    // MARK: - deleteAssets() tests
+    
+    @Test("deleteAssets returns success on 204 response")
+    func deleteAssetsSuccess() async {
+        let session = createMockSession()
+        let client = ImmichClient(baseURL: baseURL, apiKey: apiKey, session: session)
+        
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "DELETE")
+            #expect(request.url?.path == "/api/assets")
+            
+            // Verify request body
+            if let body = request.httpBody,
+               let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any] {
+                #expect((json["ids"] as? [String])?.contains("asset-1") == true)
+                #expect(json["force"] as? Bool == true)
+            }
+            
+            return mockResponse(url: request.url!, statusCode: 204)
+        }
+        
+        let result = await client.deleteAssets(ids: ["asset-1", "asset-2"], force: true)
+        #expect(result.success == true)
+        #expect(result.deletedCount == 2)
+        #expect(result.error == nil)
+    }
+    
+    @Test("deleteAssets returns failure on non-204 response")
+    func deleteAssetsFailure() async {
+        let session = createMockSession()
+        let client = ImmichClient(baseURL: baseURL, apiKey: apiKey, session: session)
+        
+        MockURLProtocol.requestHandler = { request in
+            return mockResponse(url: request.url!, statusCode: 400, json: ["error": "Bad request"])
+        }
+        
+        let result = await client.deleteAssets(ids: ["asset-1"])
+        #expect(result.success == false)
+        #expect(result.deletedCount == 0)
+        #expect(result.error?.contains("400") == true)
+    }
+    
+    @Test("deleteAssets returns success for empty list")
+    func deleteAssetsEmpty() async {
+        let session = createMockSession()
+        let client = ImmichClient(baseURL: baseURL, apiKey: apiKey, session: session)
+        
+        // Should not make any HTTP request
+        MockURLProtocol.requestHandler = { _ in
+            Issue.record("Should not make HTTP request for empty list")
+            return mockResponse(url: URL(string: "http://test")!, statusCode: 500)
+        }
+        
+        let result = await client.deleteAssets(ids: [])
+        #expect(result.success == true)
+        #expect(result.deletedCount == 0)
+    }
+    
+    // MARK: - uploadAsset with livePhotoVideoId tests
+    
+    @Test("uploadAsset includes livePhotoVideoId in request")
+    func uploadAssetWithLivePhotoVideoId() async throws {
+        let session = createMockSession()
+        let client = ImmichClient(baseURL: baseURL, apiKey: apiKey, session: session)
+        
+        // Create a temp file to upload
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempFile = tempDir.appendingPathComponent("test-live-photo.heic")
+        try "fake image data".data(using: .utf8)!.write(to: tempFile)
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+        
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/api/assets")
+            
+            // Check that livePhotoVideoId is in the multipart body
+            if let body = request.httpBody,
+               let bodyString = String(data: body, encoding: .utf8) {
+                #expect(bodyString.contains("livePhotoVideoId"))
+                #expect(bodyString.contains("video-immich-id-123"))
+            }
+            
+            return mockResponse(url: request.url!, statusCode: 201, json: [
+                "id": "new-asset-id",
+                "duplicate": false
+            ])
+        }
+        
+        let result = await client.uploadAsset(
+            fileURL: tempFile,
+            deviceAssetID: "device-asset-123",
+            fileCreatedAt: Date(),
+            fileModifiedAt: Date(),
+            livePhotoVideoId: "video-immich-id-123"
+        )
+        
+        #expect(result.success == true)
+        #expect(result.assetID == "new-asset-id")
+    }
 }


### PR DESCRIPTION
## Summary
- Add full Live Photo support - detects Live Photos and uploads both image + motion video linked together via Immich's `livePhotoVideoId` API
- Add repair mode (`--repair-live-photos`) to fix previously imported Live Photos missing their motion videos
- Add safety checks in CleanupCommand to prevent deleting Live Photos from Photos.app until motion video is confirmed backed up

## Changes

### PhotosFetcher
- Add `isLivePhoto` field to `AssetInfo` struct
- Add `LivePhotoDownloadResult` struct for dual export
- Add `downloadLivePhotoAsset()` method to export both image and paired video
- Add `hasPairedVideoResource()` helper

### ImmichClient
- Add `livePhotoVideoId` parameter to `uploadAsset()` for linking Live Photo image to video
- Add `deleteAssets()` method for repair mode cleanup

### Tracker
- Database migrations for `archived`, `is_live_photo`, and `motion_video_immich_id` columns
- Add Live Photo query methods: `isLivePhoto()`, `hasMotionVideoBackup()`, `getMotionVideoImmichID()`
- Add `getLivePhotosNeedingRepair()` for repair mode
- Add `getLivePhotoStats()` for status reporting

### ImportCommand
- Two-step upload for Live Photos: video first, then image linked to video
- Add `--repair-live-photos` flag with full repair workflow
- Track Live Photo stats in import summary

### CleanupCommand
- Skip deletion of Live Photos without confirmed motion video backup
- Show count of skipped Live Photos with suggestion to run repair first

### Tests
- 10 new Tracker tests for Live Photo functionality
- 4 new ImmichClient tests for `deleteAssets()` and `livePhotoVideoId`